### PR TITLE
Update git sha only in release build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
         buildConfigField "String", "GIT_SHA", "\"DUMMY\""
-        buildConfigField "String", "BUILD_DATE", "\"${buildDate}\""
+        buildConfigField "String", "BUILD_DATE", "\"DUMMY\""
 
         // Enable Multidex to support over 65K methods
         multiDexEnabled true
@@ -54,6 +54,7 @@ android {
     buildTypes {
         release {
             buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
+            buildConfigField "String", "BUILD_DATE", "\"${buildDate}\""
             minifyEnabled false
             if (isCircle) {
                 // The release build generated on CircleCI doesn't need to be signed with our real

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ android {
         targetSdkVersion 23
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
-        buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
+        buildConfigField "String", "GIT_SHA", "\"DUMMY\""
         buildConfigField "String", "BUILD_DATE", "\"${buildDate}\""
 
         // Enable Multidex to support over 65K methods
@@ -53,6 +53,7 @@ android {
 
     buildTypes {
         release {
+            buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
             minifyEnabled false
             if (isCircle) {
                 // The release build generated on CircleCI doesn't need to be signed with our real


### PR DESCRIPTION
- setting the git sha in default config will break the incremental build and increase the build time for debug builds since BuildConfig will always be changed if there is a new commit, this might not be intended for debug build
- we can set git sha only in release build

Source :

- https://www.reddit.com/r/androiddev/comments/3az8qd/add_a_git_sha_to_your_crash_reporting_tools/cshk90h/?st=iwpqdxmw&sh=55670f2c